### PR TITLE
Add new emojis introduced in macOS 13.3 🪼🫨🫚🪮🪿

### DIFF
--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -9271,7 +9271,8 @@
   "‼️": [
     "double_exclamation_mark",
     "exclamation",
-    "surprise"
+    "surprise",
+    "bang"
   ],
   "⁉️": [
     "exclamation_question_mark",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -9197,7 +9197,8 @@
     "delete",
     "remove",
     "cancel",
-    "red"
+    "red",
+    "x"
   ],
   "❎": [
     "cross_mark_button",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -295,7 +295,8 @@
     "scepticism",
     "disapproval",
     "disbelief",
-    "surprise"
+    "surprise",
+    "suspicious"
   ],
   "😐": [
     "neutral_face",
@@ -314,8 +315,7 @@
   ],
   "😶": [
     "face_without_mouth",
-    "face",
-    "hellokitty"
+    "face"
   ],
   "😏": [
     "smirking_face",
@@ -336,6 +336,7 @@
     "unimpressed",
     "skeptical",
     "dubious",
+    "ugh",
     "side_eye"
   ],
   "🙄": [
@@ -623,6 +624,7 @@
   ],
   "😭": [
     "loudly_crying_face",
+    "sobbing",
     "face",
     "cry",
     "tears",
@@ -738,7 +740,8 @@
     "dead",
     "skeleton",
     "creepy",
-    "death"
+    "death",
+    "dead"
   ],
   "☠️": [
     "skull_and_crossbones",
@@ -772,8 +775,7 @@
     "creepy",
     "devil",
     "demon",
-    "japanese",
-    "ogre"
+    "japanese_ogre"
   ],
   "👺": [
     "goblin",
@@ -783,8 +785,7 @@
     "monster",
     "scary",
     "creepy",
-    "japanese",
-    "goblin"
+    "japanese_goblin"
   ],
   "👻": [
     "ghost",
@@ -1048,7 +1049,8 @@
     "quiz",
     "test",
     "pass",
-    "hundred"
+    "hundred",
+    "100"
   ],
   "💢": [
     "anger_symbol",
@@ -1060,7 +1062,6 @@
     "bomb",
     "explode",
     "explosion",
-    "collision",
     "blown"
   ],
   "💫": [
@@ -1139,6 +1140,7 @@
   ],
   "👋": [
     "waving_hand",
+    "wave",
     "hands",
     "gesture",
     "goodbye",
@@ -1368,11 +1370,13 @@
   ],
   "💅": [
     "nail_polish",
+    "nail_care",
     "beauty",
     "manicure",
     "finger",
     "fashion",
-    "nail"
+    "nail",
+    "slay"
   ],
   "🤳": [
     "selfie",
@@ -1459,7 +1463,6 @@
   ],
   "👄": [
     "mouth",
-    "mouth",
     "kiss"
   ],
   "👶": [
@@ -1489,8 +1492,7 @@
   ],
   "🧑": [
     "person",
-    "gender-neutral",
-    "person"
+    "gender-neutral"
   ],
   "👱": [
     "person_blond_hair",
@@ -2130,8 +2132,7 @@
   "🕵️": [
     "detective",
     "human",
-    "spy",
-    "detective"
+    "spy"
   ],
   "🕵️‍♂️": [
     "man_detective",
@@ -2818,20 +2819,27 @@
   ],
   "🚴": [
     "person_biking",
+    "bicycle",
+    "bike",
+    "cyclist",
     "sport",
     "move"
   ],
   "🚴‍♂️": [
     "man_biking",
-    "sports",
+    "bicycle",
     "bike",
+    "cyclist",
+    "sports",
     "exercise",
     "hipster"
   ],
   "🚴‍♀️": [
     "woman_biking",
-    "sports",
+    "bicycle",
     "bike",
+    "cyclist",
+    "sports",
     "exercise",
     "hipster",
     "woman",
@@ -2839,24 +2847,31 @@
   ],
   "🚵": [
     "person_mountain_biking",
+    "bicycle",
+    "bike",
+    "cyclist",
     "sport",
     "move"
   ],
   "🚵‍♂️": [
     "man_mountain_biking",
+    "bicycle",
+    "bike",
+    "cyclist",
     "transportation",
     "sports",
     "human",
-    "race",
-    "bike"
+    "race"
   ],
   "🚵‍♀️": [
     "woman_mountain_biking",
+    "bicycle",
+    "bike",
+    "cyclist",
     "transportation",
     "sports",
     "human",
     "race",
-    "bike",
     "woman",
     "female"
   ],
@@ -3653,8 +3668,7 @@
   "🐼": [
     "panda",
     "animal",
-    "nature",
-    "panda"
+    "nature"
   ],
   "🦥": [
     "sloth",
@@ -3724,9 +3738,7 @@
     "baby_chick",
     "animal",
     "chicken",
-    "bird",
-    "yellow",
-    "canary"
+    "bird"
   ],
   "🐥": [
     "front_facing_baby_chick",
@@ -3987,7 +3999,6 @@
   "🦗": [
     "cricket",
     "animal",
-    "cricket",
     "chirp"
   ],
   "🕷️": [
@@ -4400,8 +4411,7 @@
     "bread",
     "bakery",
     "schmear",
-    "jewish",
-    "bakery"
+    "jewish_bakery"
   ],
   "🥞": [
     "pancakes",
@@ -4595,12 +4605,15 @@
     "rice_cracker",
     "food",
     "japanese",
-    "snack"
+    "snack",
+    "senbei"
   ],
   "🍙": [
     "rice_ball",
     "food",
-    "japanese"
+    "japanese",
+    "onigiri",
+    "omusubi"
   ],
   "🍚": [
     "cooked_rice",
@@ -4637,6 +4650,7 @@
   ],
   "🍢": [
     "oden",
+    "skewer",
     "food",
     "japanese"
   ],
@@ -4816,7 +4830,9 @@
   "🍮": [
     "custard",
     "dessert",
-    "food"
+    "food",
+    "pudding",
+    "flan"
   ],
   "🍯": [
     "honey_pot",
@@ -5008,6 +5024,7 @@
     "globe_showing_europe_africa",
     "globe",
     "world",
+    "earth",
     "international"
   ],
   "🌎": [
@@ -5015,6 +5032,7 @@
     "globe",
     "world",
     "USA",
+    "earth",
     "international"
   ],
   "🌏": [
@@ -5022,6 +5040,7 @@
     "globe",
     "world",
     "east",
+    "earth",
     "international"
   ],
   "🌐": [
@@ -5600,8 +5619,8 @@
   ],
   "🚲": [
     "bicycle",
+    "bike",
     "sports",
-    "bicycle",
     "exercise",
     "hipster"
   ],
@@ -6433,7 +6452,8 @@
     "thunder",
     "weather",
     "lightning bolt",
-    "fast"
+    "fast",
+    "zap"
   ],
   "❄️": [
     "snowflake",
@@ -7139,8 +7159,7 @@
     "backpack",
     "student",
     "education",
-    "bag",
-    "backpack"
+    "bag"
   ],
   "👞": [
     "man_s_shoe",
@@ -7436,8 +7455,7 @@
     "telephone",
     "technology",
     "communication",
-    "dial",
-    "telephone"
+    "dial"
   ],
   "📞": [
     "telephone_receiver",
@@ -7470,7 +7488,6 @@
   "💻": [
     "laptop",
     "technology",
-    "laptop",
     "screen",
     "display",
     "monitor"
@@ -7564,8 +7581,7 @@
     "technology",
     "program",
     "oldschool",
-    "show",
-    "television"
+    "show"
   ],
   "📷": [
     "camera",
@@ -7989,7 +8005,6 @@
   ],
   "📅": [
     "calendar",
-    "calendar",
     "schedule"
   ],
   "📆": [
@@ -8095,11 +8110,7 @@
   "✂️": [
     "scissors",
     "stationery",
-    "cut",
-    "black",
-    "cutting",
-    "tool",
-    "snip"
+    "cut"
   ],
   "🗃️": [
     "card_file_box",
@@ -8193,7 +8204,6 @@
     "pistol",
     "violence",
     "weapon",
-    "pistol",
     "revolver"
   ],
   "🏹": [
@@ -8437,7 +8447,6 @@
     "cigarette",
     "kills",
     "tobacco",
-    "cigarette",
     "joint",
     "smoke"
   ],
@@ -8465,8 +8474,7 @@
   "🗿": [
     "moai",
     "rock",
-    "easter island",
-    "moai"
+    "easter island"
   ],
   "🏧": [
     "atm_sign",
@@ -8597,6 +8605,9 @@
   ],
   "🚳": [
     "no_bicycles",
+    "no_bikes",
+    "bicycle",
+    "bike",
     "cyclist",
     "prohibited",
     "circle"
@@ -8906,8 +8917,7 @@
     "sign",
     "zodiac",
     "purple-square",
-    "astrology",
-    "scorpio"
+    "astrology"
   ],
   "♐": [
     "sagittarius",
@@ -9341,81 +9351,96 @@
     "0",
     "numbers",
     "blue-square",
-    "null"
+    "null",
+    "zero"
   ],
   "1️⃣": [
     "keycap_1",
     "blue-square",
     "numbers",
-    "1"
+    "1",
+    "one"
   ],
   "2️⃣": [
     "keycap_2",
     "numbers",
     "2",
     "prime",
-    "blue-square"
+    "blue-square",
+    "two"
   ],
   "3️⃣": [
     "keycap_3",
     "3",
     "numbers",
     "prime",
-    "blue-square"
+    "blue-square",
+    "three"
   ],
   "4️⃣": [
     "keycap_4",
     "4",
     "numbers",
-    "blue-square"
+    "blue-square",
+    "four"
   ],
   "5️⃣": [
     "keycap_5",
     "5",
     "numbers",
     "blue-square",
-    "prime"
+    "prime",
+    "five"
   ],
   "6️⃣": [
     "keycap_6",
     "6",
     "numbers",
-    "blue-square"
+    "blue-square",
+    "six"
   ],
   "7️⃣": [
     "keycap_7",
     "7",
     "numbers",
     "blue-square",
-    "prime"
+    "prime",
+    "seven"
   ],
   "8️⃣": [
     "keycap_8",
     "8",
     "blue-square",
-    "numbers"
+    "numbers",
+    "eight"
   ],
   "9️⃣": [
     "keycap_9",
     "blue-square",
     "numbers",
-    "9"
+    "9",
+    "nine"
   ],
   "🔟": [
     "keycap_10",
     "numbers",
     "10",
-    "blue-square"
+    "blue-square",
+    "ten"
   ],
   "🔠": [
     "input_latin_uppercase",
     "alphabet",
     "words",
+    "letters",
+    "uppercase",
     "blue-square"
   ],
   "🔡": [
     "input_latin_lowercase",
     "blue-square",
+    "letters",
+    "lowercase",
     "alphabet"
   ],
   "🔢": [
@@ -9894,12 +9919,10 @@
     "pride",
     "gay",
     "lgbt",
-    "glbt",
     "queer",
     "homosexual",
     "lesbian",
-    "bisexual",
-    "transgender"
+    "bisexual"
   ],
   "🏴‍☠️": [
     "pirate_flag",
@@ -10353,8 +10376,7 @@
     "flag",
     "country",
     "nation",
-    "banner",
-    "china"
+    "banner"
   ],
   "🇨🇴": [
     "flag_colombia",
@@ -10547,8 +10569,7 @@
     "flag",
     "nation",
     "country",
-    "banner",
-    "spain"
+    "banner"
   ],
   "🇪🇹": [
     "flag_ethiopia",
@@ -10603,8 +10624,7 @@
     "flag",
     "nation",
     "country",
-    "banner",
-    "micronesia"
+    "banner"
   ],
   "🇫🇴": [
     "flag_faroe_islands",
@@ -10623,8 +10643,7 @@
     "nation",
     "france",
     "french",
-    "country",
-    "france"
+    "country"
   ],
   "🇬🇦": [
     "flag_gabon",
@@ -10946,8 +10965,7 @@
     "flag",
     "nation",
     "country",
-    "banner",
-    "iran"
+    "banner"
   ],
   "🇮🇸": [
     "flag_iceland",
@@ -10964,8 +10982,7 @@
     "flag",
     "nation",
     "country",
-    "banner",
-    "italy"
+    "banner"
   ],
   "🇯🇪": [
     "flag_jersey",
@@ -11237,8 +11254,7 @@
     "flag",
     "nation",
     "country",
-    "banner",
-    "moldova"
+    "banner"
   ],
   "🇲🇪": [
     "flag_montenegro",
@@ -12034,8 +12050,7 @@
     "flag",
     "nation",
     "country",
-    "banner",
-    "turkey"
+    "banner"
   ],
   "🇹🇹": [
     "flag_trinidad_tobago",
@@ -12072,8 +12087,7 @@
     "flag",
     "nation",
     "country",
-    "banner",
-    "tanzania"
+    "banner"
   ],
   "🇺🇦": [
     "flag_ukraine",
@@ -12611,10 +12625,14 @@
   ],
   "⚧️": [
     "transgender symbol",
+    "transgender",
     "lgbtq"
   ],
   "🏳️‍⚧️": [
     "transgender flag",
+    "transgender",
+    "flag",
+    "pride",
     "lgbtq"
   ],
   "😶‍🌫️": [
@@ -12856,5 +12874,124 @@
   "🟰": [
     "heavy equals sign",
     "math"
+  ],
+  "🫨": [
+    "shaking face",
+    "dizzy",
+    "shock",
+    "blurry",
+    "earthquake"
+  ],
+  "🩷": [
+    "pink heart",
+    "valentines"
+  ],
+  "🩵": [
+    "light blue heart",
+    "ice",
+    "baby blue"
+  ],
+  "🩶": [
+    "grey heart",
+    "silver",
+    "monochrome"
+  ],
+  "🫷": [
+    "leftwards pushing hand",
+    "highfive",
+    "pressing",
+    "stop"
+  ],
+  "🫸": [
+    "rightwards pushing hand",
+    "highfive",
+    "pressing",
+    "stop"
+  ],
+  "🫎": [
+    "moose",
+    "shrek",
+    "canada",
+    "sweden",
+    "sven",
+    "cool"
+  ],
+  "🫏": [
+    "donkey",
+    "eeyore",
+    "mule"
+  ],
+  "🪽": [
+    "wing",
+    "angel",
+    "birds",
+    "flying"
+  ],
+  "🐦‍⬛": [
+    "black bird",
+    "crow"
+  ],
+  "🪿": [
+    "goose",
+    "silly",
+    "jemima",
+    "goosebumps"
+  ],
+  "🪼": [
+    "jellyfish",
+    "sting",
+    "tentacles"
+  ],
+  "🪻": [
+    "hyacinth",
+    "flower",
+    "lavender"
+  ],
+  "🫚": [
+    "ginger root",
+    "spice",
+    "yellow",
+    "cooking",
+    "gingerbread"
+  ],
+  "🫛": [
+    "pea pod",
+    "cozy",
+    "green"
+  ],
+  "🪭": [
+    "folding hand fan",
+    "flamenco",
+    "hot"
+  ],
+  "🪮": [
+    "hair pick",
+    "afro",
+    "comb"
+  ],
+  "🪇": [
+    "maracas",
+    "music",
+    "instrument",
+    "percussion"
+  ],
+  "🪈": [
+    "flute",
+    "bamboo",
+    "music",
+    "instrument",
+    "pied piper"
+  ],
+  "🪯": [
+    "khanda",
+    "Sikhism",
+    "religion"
+  ],
+  "🛜": [
+    "wireless",
+    "wifi",
+    "internet",
+    "contactless",
+    "signal"
   ]
 }

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -6824,7 +6824,8 @@
   "🤿": [
     "diving_mask",
     "sport",
-    "ocean"
+    "ocean",
+    "scuba"
   ],
   "🎽": [
     "running_shirt",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -8111,7 +8111,8 @@
   "✂️": [
     "scissors",
     "stationery",
-    "cut"
+    "cut",
+    "snip"
   ],
   "🗃️": [
     "card_file_box",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -1062,7 +1062,8 @@
     "bomb",
     "explode",
     "explosion",
-    "blown"
+    "blown",
+    "boom"
   ],
   "💫": [
     "dizzy",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -3738,7 +3738,8 @@
     "baby_chick",
     "animal",
     "chicken",
-    "bird"
+    "bird",
+    "canary"
   ],
   "🐥": [
     "front_facing_baby_chick",


### PR DESCRIPTION
This pull request adds the [new emojis introduced in macOS 13.3](https://emojipedia.org/apple/ios-16.4/new). [1]

- [x] 🫨 Shaking Face
- [x] 🩷 Pink Heart
- [x] 🩵 Light Blue Heart
- [x] 🩶 Grey Heart
- [x] 🫷 Leftwards Pushing Hand
- [x] 🫸 Rightwards Pushing Hand
- [x] 🫎 Moose
- [x] 🫏 Donkey
- [x] 🪽 Wing
- [x] 🐦‍⬛ Black Bird
- [x] 🪿 Goose
- [x] 🪼 Jellyfish
- [x] 🪻 Hyacinth
- [x] 🫚 Ginger Root
- [x] 🫛 Pea Pod
- [x] 🪭 Folding Hand Fan
- [x] 🪮 Hair Pick
- [x] 🪇 Maracas
- [x] 🪈 Flute
- [x] 🪯 Khanda
- [x] 🛜 Wireless

[1]: Yes. I totally realize that macOS 13.3 came out 2 years ago. 😇 This update is better late than never, right? 🤞