### PR TITLE
Add new emojis introduced in macOS 14.4 🐦‍🔥🍋‍🟩⛓️‍💥🍄‍🟫🙂‍↔️

### DIFF
--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -699,7 +699,8 @@
     "gas",
     "phew",
     "proud",
-    "pride"
+    "pride",
+    "triumph"
   ],
   "😡": [
     "pouting_face",
@@ -1062,8 +1063,7 @@
     "bomb",
     "explode",
     "explosion",
-    "blown",
-    "boom"
+    "blown"
   ],
   "💫": [
     "dizzy",
@@ -3739,8 +3739,7 @@
     "baby_chick",
     "animal",
     "chicken",
-    "bird",
-    "canary"
+    "bird"
   ],
   "🐥": [
     "front_facing_baby_chick",
@@ -6824,8 +6823,7 @@
   "🤿": [
     "diving_mask",
     "sport",
-    "ocean",
-    "scuba"
+    "ocean"
   ],
   "🎽": [
     "running_shirt",
@@ -8113,8 +8111,7 @@
   "✂️": [
     "scissors",
     "stationery",
-    "cut",
-    "snip"
+    "cut"
   ],
   "🗃️": [
     "card_file_box",
@@ -9199,8 +9196,7 @@
     "delete",
     "remove",
     "cancel",
-    "red",
-    "x"
+    "red"
   ],
   "❎": [
     "cross_mark_button",
@@ -9274,8 +9270,7 @@
   "‼️": [
     "double_exclamation_mark",
     "exclamation",
-    "surprise",
-    "bang"
+    "surprise"
   ],
   "⁉️": [
     "exclamation_question_mark",
@@ -12999,5 +12994,158 @@
     "internet",
     "contactless",
     "signal"
+  ],
+  "🙂‍↔️": [
+    "head shaking horizontally",
+    "disapprove",
+    "indiffernt",
+    "left"
+  ],
+  "🙂‍↕️": [
+    "head shaking vertically",
+    "down",
+    "nod"
+  ],
+  "🚶‍➡️": [
+    "person walking facing right",
+    "peerson",
+    "exercise"
+  ],
+  "🚶‍♀️‍➡️": [
+    "woman walking facing right",
+    "person",
+    "exercise"
+  ],
+  "🚶‍♂️‍➡️": [
+    "man walking facing right",
+    "person",
+    "exercise"
+  ],
+  "🧎‍➡️": [
+    "person kneeling facing right",
+    "pray"
+  ],
+  "🧎‍♀️‍➡️": [
+    "woman kneeling facing right",
+    "pray",
+    "worship"
+  ],
+  "🧎‍♂️‍➡️": [
+    "man kneeling facing right",
+    "pray",
+    "worship"
+  ],
+  "🧑‍🦯‍➡️": [
+    "person with white cane facing right",
+    "walk",
+    "walk",
+    "visually impaired",
+    "blind"
+  ],
+  "👨‍🦯‍➡️": [
+    "man with white cane facing right",
+    "visually impaired",
+    "blind",
+    "walk",
+    "stick"
+  ],
+  "👩‍🦯‍➡️": [
+    "woman with white cane facing right",
+    "stick",
+    "visually impaired",
+    "blind"
+  ],
+  "🧑‍🦼‍➡️": [
+    "person in motorized wheelchair facing right",
+    "accessibility",
+    "disability"
+  ],
+  "👨‍🦼‍➡️": [
+    "man in motorized wheelchair facing right",
+    "disability",
+    "accessibility",
+    "mobility"
+  ],
+  "👩‍🦼‍➡️": [
+    "woman in motorized wheelchair facing right",
+    "mobility",
+    "accessibility",
+    "disability"
+  ],
+  "🧑‍🦽‍➡️": [
+    "person in manual wheelchair facing right",
+    "mobility",
+    "accessibility",
+    "disability"
+  ],
+  "👨‍🦽‍➡️": [
+    "man in manual wheelchair facing right",
+    "mobility",
+    "accessibility",
+    "disability"
+  ],
+  "👩‍🦽‍➡️": [
+    "woman in manual wheelchair facing right",
+    "disability",
+    "mobility",
+    "accessibility"
+  ],
+  "🏃‍➡️": [
+    "person running facing right",
+    "exercise",
+    "jog"
+  ],
+  "🏃‍♀️‍➡️": [
+    "woman running facing right",
+    "exercise",
+    "jog"
+  ],
+  "🏃‍♂️‍➡️": [
+    "man running facing right",
+    "jog",
+    "exercise"
+  ],
+  "🧑‍🧑‍🧒": [
+    "family adult, adult, child",
+    "kid",
+    "parents"
+  ],
+  "🧑‍🧑‍🧒‍🧒": [
+    "family adult, adult, child, child",
+    "children",
+    "parents"
+  ],
+  "🧑‍🧒": [
+    "family adult, child",
+    "parent",
+    "kid"
+  ],
+  "🧑‍🧒‍🧒": [
+    "family adult, child, child",
+    "parent",
+    "children"
+  ],
+  "🐦‍🔥": [
+    "phoenix",
+    "immortal",
+    "bird",
+    "mythtical",
+    "reborn"
+  ],
+  "🍋‍🟩": [
+    "lime",
+    "fruit",
+    "acidic",
+    "citric"
+  ],
+  "🍄‍🟫": [
+    "brown mushroom",
+    "toadstool",
+    "fungus"
+  ],
+  "⛓️‍💥": [
+    "broken chain",
+    "constraint",
+    "break"
   ]
 }

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -8113,7 +8113,8 @@
   "✂️": [
     "scissors",
     "stationery",
-    "cut"
+    "cut",
+    "snip"
   ],
   "🗃️": [
     "card_file_box",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -3740,7 +3740,8 @@
     "baby_chick",
     "animal",
     "chicken",
-    "bird"
+    "bird",
+    "canary"
   ],
   "🐥": [
     "front_facing_baby_chick",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -9198,7 +9198,8 @@
     "delete",
     "remove",
     "cancel",
-    "red"
+    "red",
+    "x"
   ],
   "❎": [
     "cross_mark_button",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -1063,7 +1063,8 @@
     "bomb",
     "explode",
     "explosion",
-    "blown"
+    "blown",
+    "boom"
   ],
   "💫": [
     "dizzy",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -9273,7 +9273,8 @@
   "‼️": [
     "double_exclamation_mark",
     "exclamation",
-    "surprise"
+    "surprise",
+    "bang"
   ],
   "⁉️": [
     "exclamation_question_mark",

--- a/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
+++ b/emoji-lookup.lbaction/Contents/vendor/emojilib/emoji-en-US.json
@@ -6823,7 +6823,8 @@
   "🤿": [
     "diving_mask",
     "sport",
-    "ocean"
+    "ocean",
+    "scuba"
   ],
   "🎽": [
     "running_shirt",


### PR DESCRIPTION
This pull request adds the [new emojis introduced in macOS 14.4](https://blog.emojipedia.org/ios-17-4-emoji-changelog/). [1]

- [x] 🙂‍↔️ Head Shaking Horizontally
- [x] 🙂‍↕️ Head Shaking Vertically
- [x] 🚶‍➡️ Person Walking: Facing Right
- [x] 🚶‍♀️‍➡️ Woman Walking: Facing Right
- [x] 🚶‍♂️‍➡️ Man Walking: Facing Right
- [x] 🧎‍➡️ Person Kneeling: Facing Right
- [x] 🧎‍♀️‍➡️ Woman Kneeling: Facing Right
- [x] 🧎‍♂️‍➡️ Man Kneeling: Facing Right
- [x] 🧑‍🦯‍➡️ Person with White Cane: Facing Right
- [x] 👨‍🦯‍➡️ Man with White Cane: Facing Right
- [x] 👩‍🦯‍➡️ Woman with White Cane: Facing Right
- [x] 🧑‍🦼‍➡️ Person in Motorized Wheelchair: Facing Right
- [x] 👨‍🦼‍➡️ Man in Motorized Wheelchair: Facing Right
- [x] 👩‍🦼‍➡️ Woman in Motorized Wheelchair: Facing Right
- [x] 🧑‍🦽‍➡️ Person in Manual Wheelchair: Facing Right
- [x] 👨‍🦽‍➡️ Man in Manual Wheelchair: Facing Right
- [x] 👩‍🦽‍➡️ Woman in Manual Wheelchair: Facing Right
- [x] 🏃‍➡️ Person Running: Facing Right
- [x] 🏃‍♀️‍➡️ Woman Running: Facing Right
- [x] 🏃‍♂️‍➡️ Man Running: Facing Right
- [x] 🧑‍🧑‍🧒 Family: Adult, Adult, Child
- [x] 🧑‍🧑‍🧒‍🧒 Family: Adult, Adult, Child, Child
- [x] 🧑‍🧒 Family: Adult, Child
- [x] 🧑‍🧒‍🧒 Family: Adult, Child, Child
- [x] 🐦‍🔥 Phoenix
- [x] 🍋‍🟩 Lime
- [x] 🍄‍🟫 Brown Mushroom
- [x] ⛓️‍💥 Broken Chain

[1]: Yes. I totally realize that macOS 14.4 came out a year ago. 😇 This update is better late than never, right? 🤞